### PR TITLE
Send errors over SQS before throwing

### DIFF
--- a/lib/resizer.js
+++ b/lib/resizer.js
@@ -9,6 +9,7 @@ const http = require('follow-redirects').http;
 const https = require('follow-redirects').https;
 const s3 = new (require('aws-sdk')).S3();
 const sharp = require('sharp');
+const logger = require('./logger');
 const UploadedFile = require('./uploaded-file');
 
 const RESIZES = [
@@ -32,15 +33,17 @@ exports.work = (imgEvent) => {
     return exports.resizeAll(file.tmpPath, file.tmpS3Bucket, file.tmpS3Key, file.destPath, type);
   }).then(resized => {
     file.setResized(resized);
-    return true; // success!
+    return file.callback().then(() => true); // success!
   }).catch(err => {
+    file.setError(err);
     if ((err.fromDownload || err.fromValidate) && !err.retryable) {
-      file.setError(err);
-      return false;
+      logger.warn(`NoRetry ${err.message}`);
+      return file.callback().then(() => false);
+    } else {
+      return file.callback().then(() => {
+        throw err; // will be retried by SNS
+      });
     }
-    throw err; // will be retried by SNS
-  }).finally(() => {
-    return file.callback();
   });
 }
 


### PR DESCRIPTION
Same as PRX/cms-audio-lambda#20.  Except that this repo has a slightly different organization.